### PR TITLE
Adapt to latest nightly Rust (AllocRef API change)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [nightly-2020-02-01, nightly-2020-02-03, nightly-2020-03-01, nightly-2020-03-04]
+        rust: [nightly-2020-02-01, nightly-2020-02-03, nightly-2020-03-01, nightly-2020-03-04, nightly-2020-03-20]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [nightly-2020-02-01, nightly-2020-02-03, nightly-2020-03-01, nightly-2020-03-04, nightly-2020-03-20]
+        rust: 
+        - nightly-2020-02-01 
+        - nightly-2020-02-03
+        - nightly-2020-03-01
+        - nightly-2020-03-04
+        - nightly-2020-03-10
+        - nightly-2020-03-11
 
     steps:
     - uses: actions/checkout@v2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,12 +218,12 @@ unsafe impl AllocRef for Heap {
         self.alloc(layout)
     }
 
-    #[rustversion::all(since(2020-03-03), before(2020-03-08))]
+    #[rustversion::all(since(2020-03-03), before(2020-03-10))]
     unsafe fn alloc(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocErr> {
         self.alloc(layout).map(|p| (p, layout.size()))
     }
 
-    #[rustversion::since(2020-03-08)]
+    #[rustversion::since(2020-03-10)]
     fn alloc(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocErr> {
         self.alloc(layout).map(|p| (p, layout.size()))
     }


### PR DESCRIPTION
This change broke compilation: https://github.com/rust-lang/rust/commit/f77afc8f9c63d789519c0b1a733462ca654d894a