### PR TITLE
Add Order as const generic

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         rust: 
         - stable
-        - nightly-2020-09-24
+        - nightly-2021-03-09
 
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ documentation = "https://docs.rs/buddy_system_allocator"
 homepage = "https://github.com/rcore-os/buddy_system_allocator"
 repository = "https://github.com/rcore-os/buddy_system_allocator"
 keywords = ["allocator", "no_std", "heap"]
-version = "0.7.0"
-authors = ["Jiajie Chen <noc@jiegec.ac.cn>"]
+version = "0.8.0"
+authors = ["Jiajie Chen <noc@jiegec.ac.cn>", "Vinay Chandra Dommeti <github@vinay.vc>"]
 edition = "2018"
 license = "MIT"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,12 +234,12 @@ pub struct LockedHeap<const ORDER: usize>(Mutex<Heap<ORDER>>);
 impl<const ORDER: usize> LockedHeap<ORDER> {
     /// Creates an empty heap
     pub const fn new() -> Self {
-        LockedHeap(Mutex::new(Heap::new()))
+        LockedHeap(Mutex::new(Heap::<ORDER>::new()))
     }
 
     /// Creates an empty heap
     pub const fn empty() -> Self {
-        LockedHeap(Mutex::new(Heap::new()))
+        LockedHeap(Mutex::new(Heap::<ORDER>::new()))
     }
 }
 
@@ -290,7 +290,7 @@ impl<const ORDER: usize> LockedHeapWithRescue<ORDER> {
     #[cfg(feature = "const_fn")]
     pub const fn new(rescue: fn(&mut Heap)) -> Self {
         LockedHeapWithRescue {
-            inner: Mutex::new(Heap::new()),
+            inner: Mutex::new(Heap::<ORDER>::new()),
             rescue,
         }
     }
@@ -299,7 +299,7 @@ impl<const ORDER: usize> LockedHeapWithRescue<ORDER> {
     #[cfg(not(feature = "const_fn"))]
     pub fn new(rescue: fn(&mut Heap<ORDER>)) -> Self {
         LockedHeapWithRescue {
-            inner: Mutex::new(Heap::new()),
+            inner: Mutex::new(Heap::<ORDER>::new()),
             rescue,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod test;
 
 pub use frame::*;
 
-/// A heap that uses buddy system
+/// A heap that uses buddy system with configurable order.
 ///
 /// # Usage
 ///
@@ -35,7 +35,7 @@ pub use frame::*;
 /// ```
 /// use buddy_system_allocator::*;
 /// # use core::mem::size_of;
-/// let mut heap = Heap::empty();
+/// let mut heap = Heap::<32>::empty();
 /// # let space: [usize; 100] = [0; 100];
 /// # let begin: usize = space.as_ptr() as usize;
 /// # let end: usize = begin + 100 * size_of::<usize>();
@@ -46,9 +46,9 @@ pub use frame::*;
 ///     heap.add_to_heap(begin, end);
 /// }
 /// ```
-pub struct Heap {
-    // buddy system with max order of 32
-    free_list: [linked_list::LinkedList; 32],
+pub struct Heap<const ORDER: usize> {
+    // buddy system with max order of `ORDER`
+    free_list: [linked_list::LinkedList; ORDER],
 
     // statistics
     user: usize,
@@ -56,11 +56,11 @@ pub struct Heap {
     total: usize,
 }
 
-impl Heap {
+impl<const ORDER: usize> Heap<ORDER> {
     /// Create an empty heap
     pub const fn new() -> Self {
         Heap {
-            free_list: [linked_list::LinkedList::new(); 32],
+            free_list: [linked_list::LinkedList::new(); ORDER],
             user: 0,
             allocated: 0,
             total: 0,
@@ -198,7 +198,7 @@ impl Heap {
     }
 }
 
-impl fmt::Debug for Heap {
+impl<const ORDER: usize> fmt::Debug for Heap<ORDER> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Heap")
             .field("user", &self.user)
@@ -216,7 +216,7 @@ impl fmt::Debug for Heap {
 /// ```
 /// use buddy_system_allocator::*;
 /// # use core::mem::size_of;
-/// let mut heap = LockedHeap::new();
+/// let mut heap = LockedHeap::<32>::new();
 /// # let space: [usize; 100] = [0; 100];
 /// # let begin: usize = space.as_ptr() as usize;
 /// # let end: usize = begin + 100 * size_of::<usize>();
@@ -228,32 +228,32 @@ impl fmt::Debug for Heap {
 /// }
 /// ```
 #[cfg(feature = "use_spin")]
-pub struct LockedHeap(Mutex<Heap>);
+pub struct LockedHeap<const ORDER: usize>(Mutex<Heap<ORDER>>);
 
 #[cfg(feature = "use_spin")]
-impl LockedHeap {
+impl<const ORDER: usize> LockedHeap<ORDER> {
     /// Creates an empty heap
-    pub const fn new() -> LockedHeap {
+    pub const fn new() -> Self {
         LockedHeap(Mutex::new(Heap::new()))
     }
 
     /// Creates an empty heap
-    pub const fn empty() -> LockedHeap {
+    pub const fn empty() -> Self {
         LockedHeap(Mutex::new(Heap::new()))
     }
 }
 
 #[cfg(feature = "use_spin")]
-impl Deref for LockedHeap {
-    type Target = Mutex<Heap>;
+impl<const ORDER: usize> Deref for LockedHeap<ORDER> {
+    type Target = Mutex<Heap<ORDER>>;
 
-    fn deref(&self) -> &Mutex<Heap> {
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 #[cfg(feature = "use_spin")]
-unsafe impl GlobalAlloc for LockedHeap {
+unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeap<ORDER> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         self.0
             .lock()
@@ -274,21 +274,21 @@ unsafe impl GlobalAlloc for LockedHeap {
 /// Create a locked heap:
 /// ```
 /// use buddy_system_allocator::*;
-/// let heap = LockedHeapWithRescue::new(|heap: &mut Heap| {});
+/// let heap = LockedHeapWithRescue::new(|heap: &mut Heap<32>| {});
 /// ```
 ///
 /// Before oom, the allocator will try to call rescue function and try for one more time.
 #[cfg(feature = "use_spin")]
-pub struct LockedHeapWithRescue {
-    inner: Mutex<Heap>,
-    rescue: fn(&mut Heap),
+pub struct LockedHeapWithRescue<const ORDER: usize> {
+    inner: Mutex<Heap<ORDER>>,
+    rescue: fn(&mut Heap<ORDER>),
 }
 
 #[cfg(feature = "use_spin")]
-impl LockedHeapWithRescue {
+impl<const ORDER: usize> LockedHeapWithRescue<ORDER> {
     /// Creates an empty heap
     #[cfg(feature = "const_fn")]
-    pub const fn new(rescue: fn(&mut Heap)) -> LockedHeapWithRescue {
+    pub const fn new(rescue: fn(&mut Heap)) -> Self {
         LockedHeapWithRescue {
             inner: Mutex::new(Heap::new()),
             rescue,
@@ -297,7 +297,7 @@ impl LockedHeapWithRescue {
 
     /// Creates an empty heap
     #[cfg(not(feature = "const_fn"))]
-    pub fn new(rescue: fn(&mut Heap)) -> LockedHeapWithRescue {
+    pub fn new(rescue: fn(&mut Heap<ORDER>)) -> Self {
         LockedHeapWithRescue {
             inner: Mutex::new(Heap::new()),
             rescue,
@@ -306,16 +306,16 @@ impl LockedHeapWithRescue {
 }
 
 #[cfg(feature = "use_spin")]
-impl Deref for LockedHeapWithRescue {
-    type Target = Mutex<Heap>;
+impl<const ORDER: usize> Deref for LockedHeapWithRescue<ORDER> {
+    type Target = Mutex<Heap<ORDER>>;
 
-    fn deref(&self) -> &Mutex<Heap> {
+    fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
 #[cfg(feature = "use_spin")]
-unsafe impl GlobalAlloc for LockedHeapWithRescue {
+unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeapWithRescue<ORDER> {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let mut inner = self.inner.lock();
         match inner.alloc(layout) {

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,13 +43,13 @@ fn test_linked_list() {
 
 #[test]
 fn test_empty_heap() {
-    let mut heap = Heap::new();
+    let mut heap = Heap::<32>::new();
     assert!(heap.alloc(Layout::from_size_align(1, 1).unwrap()).is_err());
 }
 
 #[test]
 fn test_heap_add() {
-    let mut heap = Heap::new();
+    let mut heap = Heap::<32>::new();
     assert!(heap.alloc(Layout::from_size_align(1, 1).unwrap()).is_err());
 
     let space: [usize; 100] = [0; 100];
@@ -62,7 +62,7 @@ fn test_heap_add() {
 
 #[test]
 fn test_heap_oom() {
-    let mut heap = Heap::new();
+    let mut heap = Heap::<32>::new();
     let space: [usize; 100] = [0; 100];
     unsafe {
         heap.add_to_heap(space.as_ptr() as usize, space.as_ptr().add(100) as usize);
@@ -77,7 +77,7 @@ fn test_heap_oom() {
 #[test]
 fn test_heap_oom_rescue() {
     static mut SPACE: [usize; 100] = [0; 100];
-    let heap = LockedHeapWithRescue::new(|heap: &mut Heap| unsafe {
+    let heap = LockedHeapWithRescue::new(|heap: &mut Heap<32>| unsafe {
         heap.add_to_heap(SPACE.as_ptr() as usize, SPACE.as_ptr().add(100) as usize);
     });
 
@@ -88,7 +88,7 @@ fn test_heap_oom_rescue() {
 
 #[test]
 fn test_heap_alloc_and_free() {
-    let mut heap = Heap::new();
+    let mut heap = Heap::<32>::new();
     assert!(heap.alloc(Layout::from_size_align(1, 1).unwrap()).is_err());
 
     let space: [usize; 100] = [0; 100];


### PR DESCRIPTION
This PR allows to switch from the default 32 level heap to a generic heap that could be of any level.

This is a breaking change because `#![feature(const_generics_defaults)]` is incomplete.

Resolves #9 