### PR TITLE
Fix docs for Heap::init()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ impl<const ORDER: usize> Heap<ORDER> {
         self.total += total;
     }
 
-    /// Add a range of memory [start, end) to the heap
+    /// Add a range of memory [start, start+size) to the heap
     pub unsafe fn init(&mut self, start: usize, size: usize) {
         self.add_to_heap(start, start + size);
     }


### PR DESCRIPTION
The difference between `add_to_heap()` and `init()` wasn't immediately clear on the docs.rs page when I was perusing. The parameters of course give a hint but I figured the docs could be a little clearer about this.