### PR TITLE
Add support of benchmark using criterion.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,10 @@ const_fn = []
 [dependencies.spin]
 version = "0.9.3"
 optional = true
+
+[dev-dependencies]
+criterion = "0.3"
+
+[[bench]]
+name = "memory_allocator_benchmark"
+harness = false

--- a/benches/memory_allocator_benchmark.rs
+++ b/benches/memory_allocator_benchmark.rs
@@ -1,0 +1,83 @@
+#[macro_use]
+extern crate alloc;
+
+use std::sync::Arc;
+use std::thread;
+use std::thread::sleep;
+use std::time::Duration;
+
+use alloc::alloc::GlobalAlloc;
+use alloc::alloc::Layout;
+use buddy_system_allocator::LockedHeap;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+#[inline]
+pub fn large_alloc<const ORDER: usize>(heap: &LockedHeap<ORDER>) {
+    let layout = unsafe { Layout::from_size_align_unchecked(1024, 8) };
+    unsafe {
+        let addr = heap.alloc(layout);
+        heap.dealloc(addr, layout);
+    }
+}
+
+#[inline]
+pub fn small_alloc<const ORDER: usize>(heap: &LockedHeap<ORDER>) {
+    let layout = unsafe { Layout::from_size_align_unchecked(8, 8) };
+    unsafe {
+        let addr = heap.alloc(layout);
+        heap.dealloc(addr, layout);
+    }
+}
+
+#[inline]
+pub fn mutil_thread_alloc<const ORDER: usize>(heap: &'static LockedHeap<ORDER>) {
+    let mut threads = vec![];
+    let alloc = Arc::new(heap);
+    for i in 0..10 {
+        let a = alloc.clone();
+        let handle = thread::spawn(move || {
+            let layout = unsafe { Layout::from_size_align_unchecked(i * 10, 8) };
+            let addr;
+            unsafe { addr = a.alloc(layout) }
+            sleep(Duration::from_nanos(10 - i as u64));
+            unsafe { a.dealloc(addr, layout) }
+        });
+        threads.push(handle);
+    }
+    drop(alloc);
+
+    for t in threads {
+        t.join().unwrap();
+    }
+}
+
+const ORDER: usize = 32;
+static HEAP_ALLOCATOR: LockedHeap<ORDER> = LockedHeap::<ORDER>::new();
+const KERNEL_HEAP_SIZE: usize = 16 * 1024 * 1024;
+const MACHINE_ALIGN: usize = core::mem::size_of::<usize>();
+const HEAP_BLOCK: usize = KERNEL_HEAP_SIZE / MACHINE_ALIGN;
+static mut HEAP: [usize; HEAP_BLOCK] = [0; HEAP_BLOCK];
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    // init heap
+    let heap_start = unsafe { HEAP.as_ptr() as usize };
+    unsafe {
+        HEAP_ALLOCATOR
+            .lock()
+            .init(heap_start, HEAP_BLOCK * MACHINE_ALIGN);
+    }
+
+    // run benchmark
+    c.bench_function("small alloc", |b| {
+        b.iter(|| small_alloc(black_box(&HEAP_ALLOCATOR)))
+    });
+    c.bench_function("large alloc", |b| {
+        b.iter(|| large_alloc(black_box(&HEAP_ALLOCATOR)))
+    });
+    c.bench_function("mutil thread alloc", |b| {
+        b.iter(|| mutil_thread_alloc(black_box(&HEAP_ALLOCATOR)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Hi, I am thinking it would be nice to **have a benchmark to measure the performance of memory allocator**. So I build a simple benchmark architecture by [criterion.rs](https://github.com/bheisler/criterion.rs) to implement this feature. You can use `cargo bench` to run the benchmark, which is simple and dedicated for LockHeap for now.

And expected outcome will be:

```rust
small alloc             time:   [27.422 ns 27.530 ns 27.641 ns]
                        change: [-1.3652% -0.7933% -0.2747%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

large alloc             time:   [17.077 ns 17.162 ns 17.251 ns]
                        change: [-1.3983% -0.7544% -0.1074%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  6 (6.00%) high mild
  3 (3.00%) high severe

mutil thread alloc      time:   [98.124 µs 99.794 µs 101.84 µs]
                        change: [-2.0608% +1.0073% +4.6919%] (p = 0.57 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  9 (9.00%) high mild
  6 (6.00%) high severe
```

You can also check the graph in `target/criterion/report/index.html`, which looks like:

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/25260092/189475885-5f547f29-1df9-43fa-b15a-fa401abecbcb.png">

For now, the benchmark is simple and not design carefully. I think [this repo and paper](https://github.com/emeryberger/Hoard/tree/master/benchmarks) will be helpful if we want to build a nice benchmark for memory allocator.