### PR TITLE
Improve benchmark support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ optional = true
 [dev-dependencies]
 criterion = "0.3"
 ctor = "0.1.23"
+rand = "0.8.5"
+rand_chacha = "0.3.1"
 
 [[bench]]
 name = "memory_allocator_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ optional = true
 
 [dev-dependencies]
 criterion = "0.3"
+ctor = "0.1.23"
 
 [[bench]]
 name = "memory_allocator_benchmark"

--- a/benches/memory_allocator_benchmark.rs
+++ b/benches/memory_allocator_benchmark.rs
@@ -11,9 +11,14 @@ use alloc::alloc::Layout;
 use buddy_system_allocator::LockedHeap;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
+const LARGE_SIZE: usize = 1024;
+const SMALL_SIZE: usize = 8;
+const THREAD_SIZE: usize = 10;
+const ALIGN: usize = 8;
+
 #[inline]
 pub fn large_alloc<const ORDER: usize>(heap: &LockedHeap<ORDER>) {
-    let layout = unsafe { Layout::from_size_align_unchecked(1024, 8) };
+    let layout = unsafe { Layout::from_size_align_unchecked(LARGE_SIZE, ALIGN) };
     unsafe {
         let addr = heap.alloc(layout);
         heap.dealloc(addr, layout);
@@ -22,7 +27,7 @@ pub fn large_alloc<const ORDER: usize>(heap: &LockedHeap<ORDER>) {
 
 #[inline]
 pub fn small_alloc<const ORDER: usize>(heap: &LockedHeap<ORDER>) {
-    let layout = unsafe { Layout::from_size_align_unchecked(8, 8) };
+    let layout = unsafe { Layout::from_size_align_unchecked(SMALL_SIZE, ALIGN) };
     unsafe {
         let addr = heap.alloc(layout);
         heap.dealloc(addr, layout);
@@ -31,16 +36,81 @@ pub fn small_alloc<const ORDER: usize>(heap: &LockedHeap<ORDER>) {
 
 #[inline]
 pub fn mutil_thread_alloc<const ORDER: usize>(heap: &'static LockedHeap<ORDER>) {
-    let mut threads = vec![];
+    let mut threads = Vec::with_capacity(THREAD_SIZE);
     let alloc = Arc::new(heap);
-    for i in 0..10 {
-        let a = alloc.clone();
+    for i in 0..THREAD_SIZE {
+        let prethread_alloc = alloc.clone();
         let handle = thread::spawn(move || {
-            let layout = unsafe { Layout::from_size_align_unchecked(i * 10, 8) };
+            let layout = unsafe { Layout::from_size_align_unchecked(i * THREAD_SIZE, ALIGN) };
             let addr;
-            unsafe { addr = a.alloc(layout) }
-            sleep(Duration::from_nanos(10 - i as u64));
-            unsafe { a.dealloc(addr, layout) }
+            unsafe { addr = prethread_alloc.alloc(layout) }
+            sleep(Duration::from_nanos((THREAD_SIZE - i) as u64));
+            unsafe { prethread_alloc.dealloc(addr, layout) }
+        });
+        threads.push(handle);
+    }
+    drop(alloc);
+
+    for t in threads {
+        t.join().unwrap();
+    }
+}
+
+/// # From **Hoard** benchmark: threadtest.cpp, rewrite in Rust
+///
+/// # Warnning
+///
+/// This benchmark generally needs long time to finish
+///
+/// ----------------------------------------------------------------------
+/// Hoard: A Fast, Scalable, and Memory-Efficient Allocator
+///       for Shared-Memory Multiprocessors
+/// Contact author: Emery Berger, http://www.cs.utexas.edu/users/emery
+//
+/// Copyright (c) 1998-2000, The University of Texas at Austin.
+///
+/// This library is free software; you can redistribute it and/or modify
+/// it under the terms of the GNU Library General Public License as
+/// published by the Free Software Foundation, http://www.fsf.org.
+///
+/// This library is distributed in the hope that it will be useful, but
+/// WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+/// Library General Public License for more details.
+/// ----------------------------------------------------------------------
+///
+#[inline]
+pub fn thread_test<const ORDER: usize>(heap: &'static LockedHeap<ORDER>) {
+    const N_ITERATIONS: usize = 50;
+    const N_OBJECTS: usize = 30000;
+    const N_THREADS: usize = 10;
+    const OBJECT_SIZE: usize = 1;
+
+    let mut threads = Vec::with_capacity(THREAD_SIZE);
+    let alloc = Arc::new(heap);
+
+    for i in 0..THREAD_SIZE {
+        let prethread_alloc = alloc.clone();
+        let handle = thread::spawn(move || {
+            // a = new Foo * [nobjects / nthreads];
+            let layout = unsafe {
+                Layout::from_size_align_unchecked(SMALL_SIZE * (N_OBJECTS / N_THREADS), ALIGN)
+            };
+            let addr = unsafe { prethread_alloc.alloc(layout) };
+            for j in 0..N_ITERATIONS {
+                // inner object:
+                // a[i] = new Foo[objSize];
+                let mut addrs = vec![];
+                let layout =
+                    unsafe { Layout::from_size_align_unchecked(SMALL_SIZE * OBJECT_SIZE, ALIGN) };
+                for i in 0..(N_OBJECTS / N_THREADS) {
+                    addrs.push(unsafe { prethread_alloc.alloc(layout) });
+                }
+                for addr in addrs {
+                    unsafe { prethread_alloc.dealloc(addr, layout) }
+                }
+            }
+            unsafe { prethread_alloc.dealloc(addr, layout) }
         });
         threads.push(handle);
     }
@@ -76,6 +146,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     });
     c.bench_function("mutil thread alloc", |b| {
         b.iter(|| mutil_thread_alloc(black_box(&HEAP_ALLOCATOR)))
+    });
+    c.bench_function("threadtest", |b| {
+        b.iter(|| thread_test(black_box(&HEAP_ALLOCATOR)))
     });
 }
 

--- a/benches/memory_allocator_benchmark.rs
+++ b/benches/memory_allocator_benchmark.rs
@@ -74,11 +74,9 @@ pub fn mutil_thread_random_size<const ORDER: usize>(heap: &'static LockedHeap<OR
     }
 }
 
-/// # From **Hoard** benchmark: threadtest.cpp, rewrite in Rust
+/// Multithread benchmark inspired by **Hoard** benchmark
 ///
-/// # Warnning
-///
-/// This benchmark generally needs long time to finish
+/// Warning: This benchmark generally needs long time to finish
 ///
 /// ----------------------------------------------------------------------
 /// Hoard: A Fast, Scalable, and Memory-Efficient Allocator
@@ -155,7 +153,7 @@ static mut HEAP: [usize; HEAP_BLOCK] = [0; HEAP_BLOCK];
 #[global_allocator]
 static HEAP_ALLOCATOR: LockedHeap<ORDER> = LockedHeap::<ORDER>::new();
 
-/// # Init heap
+/// Init heap
 ///
 /// We need `ctor` here because benchmark is running behind the std enviroment,
 /// which means std will do some initialization before execute `fn main()`.


### PR DESCRIPTION
1. Use heap as global allocator so that we can use collections from std to build nicer benchmark
2. Add random object size + multithread benchmark
3. Add threadtest inspired by [**Hoard**.](https://github.com/emeryberger/Hoard/blob/master/benchmarks/threadtest/threadtest.cpp)