### PR TITLE
Split large range when adding rather than panicking.

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -61,7 +61,10 @@ impl<const ORDER: usize> FrameAllocator<ORDER> {
             } else {
                 32
             };
-            let size = min(lowbit, prev_power_of_two(end - current_start));
+            let size = min(
+                min(lowbit, prev_power_of_two(end - current_start)),
+                1 << (ORDER - 1),
+            );
             total += size;
 
             self.free_list[size.trailing_zeros() as usize].insert(current_start);

--- a/src/test.rs
+++ b/src/test.rs
@@ -122,11 +122,20 @@ fn test_frame_allocator_add() {
 }
 
 #[test]
-#[should_panic]
-fn test_frame_allocator_add_large_size_panics() {
+fn test_frame_allocator_allocate_large() {
+    let mut frame = FrameAllocator::<32>::new();
+    assert_eq!(frame.alloc(10_000_000_000), None);
+}
+
+#[test]
+fn test_frame_allocator_add_large_size_split() {
     let mut frame = FrameAllocator::<32>::new();
 
     frame.insert(0..10_000_000_000);
+
+    assert_eq!(frame.alloc(0x8000_0001), None);
+    assert_eq!(frame.alloc(0x8000_0000), Some(0x8000_0000));
+    assert_eq!(frame.alloc(0x8000_0000), Some(0x1_0000_0000));
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -143,6 +143,7 @@ fn test_frame_allocator_add_large_size() {
     let mut frame = FrameAllocator::<33>::new();
 
     frame.insert(0..10_000_000_000);
+    assert_eq!(frame.alloc(0x8000_0001), Some(0x1_0000_0000));
 }
 
 #[test]


### PR DESCRIPTION
If the order of the allocator isn't large enough for the ideal class of the range being added, use the largest available class.