### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ use_spin = ["spin"]
 const_fn = []
 
 [dependencies.spin]
-version = "0.9.3"
+version = "0.9.8"
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)