### PR TITLE
fix some clippy warnings, use `PhantomData` for the lifetime marker in Iter and IterMut

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -115,7 +115,7 @@ impl<const ORDER: usize> FrameAllocator<ORDER> {
                     }
                 }
 
-                let result = self.free_list[class].iter().next().clone();
+                let result = self.free_list[class].iter().next();
                 if let Some(result_ref) = result {
                     let result = *result_ref;
                     self.free_list[class].remove(&result);
@@ -155,7 +155,7 @@ impl<const ORDER: usize> FrameAllocator<ORDER> {
         let mut current_class = class;
         while current_class < self.free_list.len() {
             let buddy = current_ptr ^ (1 << current_class);
-            if self.free_list[current_class].remove(&buddy) == true {
+            if self.free_list[current_class].remove(&buddy) {
                 // Free buddy found
                 current_ptr = min(current_ptr, buddy);
                 current_class += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,9 @@ extern crate spin;
 
 extern crate alloc;
 
-use core::alloc::{GlobalAlloc, Layout};
+#[cfg(feature = "use_spin")]
+use core::alloc::GlobalAlloc;
+use core::alloc::Layout;
 use core::cmp::{max, min};
 use core::fmt;
 use core::mem::size_of;
@@ -76,7 +78,7 @@ impl<const ORDER: usize> Heap<ORDER> {
     pub unsafe fn add_to_heap(&mut self, mut start: usize, mut end: usize) {
         // avoid unaligned access on some platforms
         start = (start + size_of::<usize>() - 1) & (!size_of::<usize>() + 1);
-        end = end & (!size_of::<usize>() + 1);
+        end &= !size_of::<usize>() + 1;
         assert!(start <= end);
 
         let mut total = 0;
@@ -338,5 +340,5 @@ unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeapWithRescue<ORDER> {
 }
 
 pub(crate) fn prev_power_of_two(num: usize) -> usize {
-    1 << (8 * (size_of::<usize>()) - num.leading_zeros() as usize - 1)
+    1 << (usize::BITS as usize - num.leading_zeros() as usize - 1)
 }

--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -1,6 +1,6 @@
 //! Provide the intrusive LinkedList
-#![allow(dead_code)]
 
+use core::marker::PhantomData;
 use core::{fmt, ptr};
 
 /// An intrusive linked list
@@ -52,7 +52,7 @@ impl LinkedList {
     pub fn iter(&self) -> Iter {
         Iter {
             curr: self.head,
-            list: self,
+            list: PhantomData,
         }
     }
 
@@ -61,7 +61,7 @@ impl LinkedList {
         IterMut {
             prev: &mut self.head as *mut *mut usize as *mut usize,
             curr: self.head,
-            list: self,
+            list: PhantomData,
         }
     }
 }
@@ -75,7 +75,7 @@ impl fmt::Debug for LinkedList {
 /// An iterator over the linked list
 pub struct Iter<'a> {
     curr: *mut usize,
-    list: &'a LinkedList,
+    list: PhantomData<&'a LinkedList>,
 }
 
 impl<'a> Iterator for Iter<'a> {
@@ -117,7 +117,7 @@ impl ListNode {
 
 /// A mutable iterator over the linked list
 pub struct IterMut<'a> {
-    list: &'a mut LinkedList,
+    list: PhantomData<&'a mut LinkedList>,
     prev: *mut usize,
     curr: *mut usize,
 }


### PR DESCRIPTION
fix some clippy warnings

- 1 redundant clone because `Option<&usize>` which implements the `Copy` trait
- some style issues（GlobalAlloc  is unused when "default-features = false"）
- 1 clippy::manual_bits 8 * (size_of::<usize>()) -> usize::BITS as usize

feat: use marker for the lifetime marker in Iter and IterMut

- remove the `allow(dead_code)` and reduce size of Iter and IterMut, without any compiler warnings
- `PhantomData`: https://doc.rust-lang.org/core/marker/struct.PhantomData.html