### PR TITLE
Fix incorrect attempted merging at maximum order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ version = "0.9.8"
 optional = true
 
 [dev-dependencies]
-criterion = "0.3"
-ctor = "0.1.23"
+criterion = "0.5.1"
+ctor = "0.2.6"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 

--- a/benches/memory_allocator_benchmark.rs
+++ b/benches/memory_allocator_benchmark.rs
@@ -12,6 +12,7 @@ use alloc::alloc::GlobalAlloc;
 use alloc::alloc::Layout;
 use buddy_system_allocator::LockedHeap;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::{Rng, SeedableRng};
 
 const SMALL_SIZE: usize = 8;
 const LARGE_SIZE: usize = 1024 * 1024; // 1M
@@ -41,10 +42,6 @@ pub fn large_alloc<const ORDER: usize>(heap: &LockedHeap<ORDER>) {
 #[inline]
 pub fn mutil_thread_random_size<const ORDER: usize>(heap: &'static LockedHeap<ORDER>) {
     const THREAD_SIZE: usize = 10;
-
-    use rand::prelude::*;
-    use rand::{Rng, SeedableRng};
-    use rand_chacha::ChaCha8Rng;
 
     let mut threads = Vec::with_capacity(THREAD_SIZE);
     let alloc = Arc::new(heap);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,8 @@ impl<const ORDER: usize> Heap<ORDER> {
             // Merge free buddy lists
             let mut current_ptr = ptr.as_ptr() as usize;
             let mut current_class = class;
-            while current_class < self.free_list.len() {
+
+            while current_class < self.free_list.len() - 1 {
                 let buddy = current_ptr ^ (1 << current_class);
                 let mut flag = false;
                 for block in self.free_list[current_class].iter_mut() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeap<ORDER> {
             .lock()
             .alloc(layout)
             .ok()
-            .map_or(0 as *mut u8, |allocation| allocation.as_ptr())
+            .map_or(core::ptr::null_mut(), |allocation| allocation.as_ptr())
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
@@ -328,7 +328,7 @@ unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeapWithRescue<ORDER> {
                 inner
                     .alloc(layout)
                     .ok()
-                    .map_or(0 as *mut u8, |allocation| allocation.as_ptr())
+                    .map_or(core::ptr::null_mut(), |allocation| allocation.as_ptr())
             }
         }
     }


### PR DESCRIPTION
Heap allocator should not attempt to merge regions on dealloc if the merged region would be greater than the maximum order. Similar bug may exist in `FrameAllocator`.

Fixes #14.