### PR TITLE
Add feature flag for alloc dependency.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,5 +22,7 @@ jobs:
       run: rustup default ${{ matrix.rust }}
     - name: Build
       run: cargo build --verbose
+    - name: Build without default features
+      run: cargo build --no-default-features --verbose
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,19 @@ homepage = "https://github.com/rcore-os/buddy_system_allocator"
 repository = "https://github.com/rcore-os/buddy_system_allocator"
 keywords = ["allocator", "no_std", "heap"]
 version = "0.9.1"
-authors = ["Jiajie Chen <c@jia.je>", "Vinay Chandra Dommeti <github@vinay.vc>", "Andrew Walbran <qwandor@google.com>"]
+authors = [
+  "Jiajie Chen <c@jia.je>",
+  "Vinay Chandra Dommeti <github@vinay.vc>",
+  "Andrew Walbran <qwandor@google.com>",
+]
 edition = "2021"
 license = "MIT"
 
 [features]
-default = ["use_spin"]
-use_spin = ["spin"]
+default = ["alloc", "use_spin"]
+alloc = []
 const_fn = []
+use_spin = ["spin"]
 
 [dependencies.spin]
 version = "0.9.8"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ You can also use `FrameAllocator` and `LockedHeapWithRescue`, see their document
 
 ## Features
 
-- **`use_spin`** (default): Provide a `LockedHeap` type that implements the [`GlobalAlloc`] trait by using a spinlock.
+- **`alloc`** (default): Provide `FrameAllocator` and `LockedFrameAllocator`, which depend on a
+  global allocator.
+- **`use_spin`** (default): Provide a `LockedHeap` type that implements the [`GlobalAlloc`] trait by
+  using a spinlock.
 - **`const_fn`** (nightly only): Provide const fn version of `LockedHeapWithRescue::new`.
 
 [`GlobalAlloc`]: https://doc.rust-lang.org/nightly/core/alloc/trait.GlobalAlloc.html
@@ -41,7 +44,7 @@ Some code comes from phil-opp's linked-list-allocator.
 
 Licensed under MIT License. Thanks phill-opp's linked-list-allocator for inspirations and interface.
 
-[crate-img]:     https://img.shields.io/crates/v/buddy_system_allocator.svg
-[crate]:         https://crates.io/crates/buddy_system_allocator
-[docs-img]:      https://docs.rs/buddy_system_allocator/badge.svg
-[docs]:          https://docs.rs/buddy_system_allocator
+[crate-img]: https://img.shields.io/crates/v/buddy_system_allocator.svg
+[crate]: https://crates.io/crates/buddy_system_allocator
+[docs-img]: https://docs.rs/buddy_system_allocator/badge.svg
+[docs]: https://docs.rs/buddy_system_allocator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ extern crate std;
 #[cfg(feature = "use_spin")]
 extern crate spin;
 
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 #[cfg(feature = "use_spin")]
@@ -22,11 +23,13 @@ use core::ptr::NonNull;
 #[cfg(feature = "use_spin")]
 use spin::Mutex;
 
+#[cfg(feature = "alloc")]
 mod frame;
 pub mod linked_list;
 #[cfg(test)]
 mod test;
 
+#[cfg(feature = "alloc")]
 pub use frame::*;
 
 /// A heap that uses buddy system with configurable order.


### PR DESCRIPTION
This allows parts of the crate to be used without a global allocator. This can be useful for programs which need some limited allocation without allowing arbitrary allocation.