### PR TITLE
Improve documentation for buddy system heap order explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To use buddy_system_allocator for global allocator:
 use buddy_system_allocator::LockedHeap;
 
 #[global_allocator]
-static HEAP_ALLOCATOR: LockedHeap = LockedHeap::<32>::empty();
+static HEAP_ALLOCATOR: LockedHeap = LockedHeap::<33>::empty();
 ```
 
 To init the allocator:

--- a/benches/memory_allocator_benchmark.rs
+++ b/benches/memory_allocator_benchmark.rs
@@ -138,7 +138,7 @@ pub fn thread_test() {
     }
 }
 
-const ORDER: usize = 32;
+const ORDER: usize = 33;
 const MACHINE_ALIGN: usize = core::mem::size_of::<usize>();
 /// for now 128M is needed
 /// TODO: reduce memory use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,10 @@ pub use frame::*;
 /// ```
 /// use buddy_system_allocator::*;
 /// # use core::mem::size_of;
-/// let mut heap = Heap::<32>::empty();
+/// // The max order of the buddy system is `ORDER - 1`.
+/// // For example, to create a heap with a maximum block size of 2^32 bytes,
+/// // you should define the heap with `ORDER = 33`.
+/// let mut heap = Heap::<33>::empty();
 /// # let space: [usize; 100] = [0; 100];
 /// # let begin: usize = space.as_ptr() as usize;
 /// # let end: usize = begin + 100 * size_of::<usize>();
@@ -51,7 +54,7 @@ pub use frame::*;
 /// }
 /// ```
 pub struct Heap<const ORDER: usize> {
-    // buddy system with max order of `ORDER`
+    // buddy system with max order of `ORDER - 1`
     free_list: [linked_list::LinkedList; ORDER],
 
     // statistics
@@ -229,7 +232,10 @@ impl<const ORDER: usize> fmt::Debug for Heap<ORDER> {
 /// ```
 /// use buddy_system_allocator::*;
 /// # use core::mem::size_of;
-/// let mut heap = LockedHeap::<32>::new();
+/// // The max order of the buddy system is `ORDER - 1`.
+/// // For example, to create a heap with a maximum block size of 2^32 bytes,
+/// // you should define the heap with `ORDER = 33`.
+/// let mut heap = LockedHeap::<33>::new();
 /// # let space: [usize; 100] = [0; 100];
 /// # let begin: usize = space.as_ptr() as usize;
 /// # let end: usize = begin + 100 * size_of::<usize>();
@@ -287,7 +293,7 @@ unsafe impl<const ORDER: usize> GlobalAlloc for LockedHeap<ORDER> {
 /// Create a locked heap:
 /// ```
 /// use buddy_system_allocator::*;
-/// let heap = LockedHeapWithRescue::new(|heap: &mut Heap<32>, layout: &core::alloc::Layout| {});
+/// let heap = LockedHeapWithRescue::new(|heap: &mut Heap<33>, layout: &core::alloc::Layout| {});
 /// ```
 ///
 /// Before oom, the allocator will try to call rescue function and try for one more time.

--- a/src/test.rs
+++ b/src/test.rs
@@ -69,7 +69,7 @@ fn test_heap_add_large() {
     // 512 bytes of space
     let space: [u8; 512] = [0; 512];
     unsafe {
-        heap.add_to_heap(space.as_ptr() as usize, space.as_ptr().add(100) as usize);
+        heap.add_to_heap(space.as_ptr() as usize, space.as_ptr().add(512) as usize);
     }
     let addr = heap.alloc(Layout::from_size_align(1, 1).unwrap());
     assert!(addr.is_ok());


### PR DESCRIPTION
- Clarify that the real order of the buddy system is `ORDER - 1`.
- Also a fix for the test in my last PR #35  (Sorry for my fault)