### PR TITLE
Update dependencies, and don't use default dependencies of spin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ alloc = []
 use_spin = ["spin"]
 
 [dependencies.spin]
-version = "0.9.8"
+version = "0.10.0"
 optional = true
 
 [dev-dependencies]
-criterion = "0.5.1"
-ctor = "0.2.6"
-rand = "0.8.5"
-rand_chacha = "0.3.1"
+criterion = "0.6.0"
+ctor = "0.4.2"
+rand = "0.9.2"
+rand_chacha = "0.9.0"
 
 [[bench]]
 name = "memory_allocator_benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ use_spin = ["spin"]
 [dependencies.spin]
 version = "0.10.0"
 optional = true
+default-features = false
+features = ["spin_mutex"]
 
 [dev-dependencies]
 criterion = "0.6.0"


### PR DESCRIPTION
This avoids pulling in some transitive dependencies.