### PR TITLE
refactor: make linked list iterator lifetimes explicit

### DIFF
--- a/src/linked_list.rs
+++ b/src/linked_list.rs
@@ -55,7 +55,7 @@ impl LinkedList {
     }
 
     /// Return an iterator over the items in the list
-    pub fn iter(&self) -> Iter {
+    pub fn iter(&self) -> Iter<'_> {
         Iter {
             curr: self.head,
             list: PhantomData,
@@ -63,7 +63,7 @@ impl LinkedList {
     }
 
     /// Return an mutable iterator over the items in the list
-    pub fn iter_mut(&mut self) -> IterMut {
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
         IterMut {
             prev: &mut self.head as *mut *mut usize as *mut usize,
             curr: self.head,


### PR DESCRIPTION
This PR makes the return lifetimes of `LinkedList::iter` and `LinkedList::iter_mut` explicit.

Specific changes include:
- Updated `LinkedList::iter` to return `Iter<'_>`.
- Updated `LinkedList::iter_mut` to return `IterMut<'_>`.
- Kept behavior unchanged while removing the current `mismatched_lifetime_syntaxes` warnings on newer toolchains.

Why this is useful:
- This is a minimal code health improvement.
- It keeps the API behavior exactly the same.
- It reduces warning noise during `cargo test` and `cargo test --doc`.

Testing:
- Ran `cargo test`.
- Ran `cargo test --doc`.
