### PR TITLE
添加 Heap dealloc free-list scan benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /target
 **/*.rs.bk
 Cargo.lock
-.omo/
-core

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.omo/
+core

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,3 +34,7 @@ rand_chacha = "0.10.0"
 [[bench]]
 name = "memory_allocator_benchmark"
 harness = false
+
+[[bench]]
+name = "heap_dealloc_scan"
+harness = false

--- a/benches/heap_dealloc_scan.rs
+++ b/benches/heap_dealloc_scan.rs
@@ -5,7 +5,7 @@
 //! their lower-half buddies.  Each dealloc must linearly scan the free list to
 //! find its buddy — exposing the O(N) scan path in the intrusive linked list.
 //!
-//! Multiple sizes are benchmarked (100, 500, 1000, 2000, 5000, 10000 pairs)
+//! Multiple sizes are benchmarked (100, 500, 1000, 2000, 5000 pairs)
 //! so the quadratic degradation is visible in the Criterion report.
 //!
 //! # Strategy

--- a/benches/heap_dealloc_scan.rs
+++ b/benches/heap_dealloc_scan.rs
@@ -1,0 +1,164 @@
+//! Benchmark for Heap::dealloc free-list scan cost at different scales.
+//!
+//! Constructs a fragmented heap where `free_list[class_6]` accumulates a long
+//! chain of freed higher-half blocks, then measures the cost of deallocating
+//! their lower-half buddies.  Each dealloc must linearly scan the free list to
+//! find its buddy — exposing the O(N) scan path in the intrusive linked list.
+//!
+//! Multiple sizes are benchmarked (100, 500, 1000, 2000, 5000, 10000 pairs)
+//! so the quadratic degradation is visible in the Criterion report.
+//!
+//! # Strategy
+//!
+//! 1. Allocate all possible 64-byte blocks to drain class-6.
+//! 2. Identify real buddy pairs via `addr ^ BLOCK_SIZE`.
+//! 3. Filter every-other 128-byte parent so class-7 doesn't cascade-merge.
+//! 4. Free all higher-half buddies (builds a long `free_list[6]`).
+//! 5. Measure: free all lower-half buddies in address order.
+//!    Each call pushes itself to the head, then scans toward the tail
+//!    where its buddy sits — the scan depth shrinks as pairs are consumed,
+//!    averaging ~N/2 per dealloc, giving total ≈ O(N²/2) pointer chases.
+
+use core::alloc::Layout;
+use core::ptr::NonNull;
+use std::collections::BTreeSet;
+
+use buddy_system_allocator::Heap;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Max order.  `free_list` has `ORDER` slots.  Class `ORDER-1` = 22 → 4 MiB.
+const ORDER: usize = 23;
+
+/// Total backing memory (4 MiB).
+const HEAP_BYTES: usize = 4 * 1024 * 1024;
+
+/// Number of `usize` words.
+const HEAP_WORDS: usize = HEAP_BYTES / core::mem::size_of::<usize>();
+
+/// Target size class: 64 bytes → class 6 (2^6).
+const BLOCK_SIZE: usize = 64;
+
+/// Degradation curve — number of buddy *pairs* to measure at each point.
+const PAIR_SIZES: &[usize] = &[100, 500, 1000, 2000, 5000, 10000];
+
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
+
+struct BenchState {
+    heap: Heap<ORDER>,
+    #[allow(dead_code)]
+    backing: Box<[usize]>,          // must outlive `heap`
+    layout: Layout,
+    lower_ptrs: Vec<NonNull<u8>>,   // sorted (ascending address)
+}
+
+// ---------------------------------------------------------------------------
+// Setup (parameterised by target pair count)
+// ---------------------------------------------------------------------------
+
+/// Build a heap where `free_list[6]` holds `target_pairs` higher-half blocks,
+/// ready for their lower-half buddies to be deallocated.
+fn setup_fragmented_heap(target_pairs: usize) -> BenchState {
+    // 1. backing memory -------------------------------------------------------
+
+    let mut backing = vec![0usize; HEAP_WORDS].into_boxed_slice();
+    let start = backing.as_mut_ptr() as usize;
+    let size = backing.len() * core::mem::size_of::<usize>();
+
+    let mut heap = Heap::<ORDER>::empty();
+    unsafe { heap.init(start, size); }
+
+    let layout =
+        Layout::from_size_align(BLOCK_SIZE, core::mem::size_of::<usize>()).unwrap();
+
+    // 2. allocate all 64-byte blocks (drain class-6 and above) ----------------
+
+    let mut ptrs: Vec<NonNull<u8>> = Vec::new();
+    loop {
+        match heap.alloc(layout) {
+            Ok(ptr) => ptrs.push(ptr),
+            Err(()) => break,
+        }
+    }
+
+    // 3. identify real buddy pairs --------------------------------------------
+
+    let mut addrs: Vec<usize> = ptrs.iter().map(|p| p.as_ptr() as usize).collect();
+    addrs.sort_unstable();
+
+    let addr_set: BTreeSet<usize> = addrs.iter().copied().collect();
+
+    let mut pairs: Vec<(usize, usize)> = Vec::new(); // (lower, higher)
+    for &addr in &addrs {
+        if addr & BLOCK_SIZE != 0 {
+            continue; // skip higher halves during discovery
+        }
+        let buddy = addr ^ BLOCK_SIZE;
+        if addr_set.contains(&buddy) {
+            pairs.push((addr, buddy));
+        }
+    }
+
+    // 4. filter: skip adjacent 128-byte parents to isolate class-6 scan -------
+
+    pairs.retain(|(lower, _)| lower & (2 * BLOCK_SIZE) == 0);
+
+    assert!(
+        pairs.len() >= target_pairs,
+        "not enough buddy pairs: need {target_pairs}, have {} — increase HEAP_BYTES",
+        pairs.len()
+    );
+    pairs.truncate(target_pairs);
+
+    // 5. sort by lower address → buddy = oldest in list when freed in order ---
+
+    pairs.sort_unstable_by_key(|(lower, _)| *lower);
+
+    let higher_ptrs: Vec<NonNull<u8>> = pairs
+        .iter()
+        .map(|(_, higher)| unsafe { NonNull::new_unchecked(*higher as *mut u8) })
+        .collect();
+
+    let lower_ptrs: Vec<NonNull<u8>> = pairs
+        .iter()
+        .map(|(lower, _)| unsafe { NonNull::new_unchecked(*lower as *mut u8) })
+        .collect();
+
+    // 6. build long free list — free higher halves (no merge: buddies still allocated)
+
+    for ptr in &higher_ptrs {
+        unsafe { heap.dealloc(*ptr, layout); }
+    }
+
+    BenchState { heap, backing, layout, lower_ptrs }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks (one per scale)
+// ---------------------------------------------------------------------------
+
+pub fn bench_heap_dealloc_freelist_scan(c: &mut Criterion) {
+    for &n in PAIR_SIZES {
+        let name = format!("heap_dealloc_freelist_scan/{n}_pairs");
+        c.bench_function(&name, |b| {
+            b.iter_batched(
+                || setup_fragmented_heap(n),
+                |mut state: BenchState| {
+                    for ptr in &state.lower_ptrs {
+                        unsafe { state.heap.dealloc(*ptr, state.layout); }
+                    }
+                    std::hint::black_box(state.heap.stats_alloc_actual());
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, bench_heap_dealloc_freelist_scan);
+criterion_main!(benches);

--- a/benches/heap_dealloc_scan.rs
+++ b/benches/heap_dealloc_scan.rs
@@ -43,7 +43,7 @@ const HEAP_WORDS: usize = HEAP_BYTES / core::mem::size_of::<usize>();
 const BLOCK_SIZE: usize = 64;
 
 /// Degradation curve — number of buddy *pairs* to measure at each point.
-const PAIR_SIZES: &[usize] = &[100, 500, 1000, 2000, 5000, 10000];
+const PAIR_SIZES: &[usize] = &[100, 500, 1000, 2000, 5000];
 
 // ---------------------------------------------------------------------------
 // State

--- a/benches/memory_allocator_benchmark.rs
+++ b/benches/memory_allocator_benchmark.rs
@@ -40,7 +40,7 @@ pub fn large_alloc<const ORDER: usize>(heap: &LockedHeap<ORDER>) {
 
 /// Multithreads alloc random sizes of object
 #[inline]
-pub fn mutil_thread_random_size<const ORDER: usize>(heap: &'static LockedHeap<ORDER>) {
+pub fn multi_thread_random_size<const ORDER: usize>(heap: &'static LockedHeap<ORDER>) {
     const THREAD_SIZE: usize = 10;
 
     let mut threads = Vec::with_capacity(THREAD_SIZE);
@@ -179,8 +179,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("large alloc", |b| {
         b.iter(|| large_alloc(std::hint::black_box(&HEAP_ALLOCATOR)))
     });
-    c.bench_function("mutil thread random size", |b| {
-        b.iter(|| mutil_thread_random_size(std::hint::black_box(&HEAP_ALLOCATOR)))
+    c.bench_function("multi thread random size", |b| {
+        b.iter(|| multi_thread_random_size(std::hint::black_box(&HEAP_ALLOCATOR)))
     });
     c.bench_function("threadtest", |b| b.iter(thread_test));
 }

--- a/benches/memory_allocator_benchmark.rs
+++ b/benches/memory_allocator_benchmark.rs
@@ -11,8 +11,8 @@ use std::time::Duration;
 use alloc::alloc::GlobalAlloc;
 use alloc::alloc::Layout;
 use buddy_system_allocator::LockedHeap;
-use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use rand::{Rng, SeedableRng};
+use criterion::{Criterion, criterion_group, criterion_main};
+use rand::{RngExt, SeedableRng};
 
 const SMALL_SIZE: usize = 8;
 const LARGE_SIZE: usize = 1024 * 1024; // 1M
@@ -53,7 +53,7 @@ pub fn mutil_thread_random_size<const ORDER: usize>(heap: &'static LockedHeap<OR
             let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(i as u64);
             // generate a random object size in range of [SMALL_SIZE ..= LARGE_SIZE]
             let layout = unsafe {
-                Layout::from_size_align_unchecked(rng.gen_range(SMALL_SIZE..=LARGE_SIZE), ALIGN)
+                Layout::from_size_align_unchecked(rng.random_range(SMALL_SIZE..=LARGE_SIZE), ALIGN)
             };
             let addr = unsafe { prethread_alloc.alloc(layout) };
 
@@ -160,9 +160,9 @@ static HEAP_ALLOCATOR: LockedHeap<ORDER> = LockedHeap::<ORDER>::new();
 ///
 /// So the solution in this dilemma is to run `fn init_heap()` in initialization phase
 /// rather than in `fn main()`. We need `ctor` to do this.
-#[ctor]
+#[ctor(unsafe)]
 fn init_heap() {
-    let heap_start = unsafe { HEAP.as_ptr() as usize };
+    let heap_start = core::ptr::addr_of!(HEAP) as usize;
     unsafe {
         HEAP_ALLOCATOR
             .lock()
@@ -174,13 +174,13 @@ fn init_heap() {
 pub fn criterion_benchmark(c: &mut Criterion) {
     // run benchmark
     c.bench_function("small alloc", |b| {
-        b.iter(|| small_alloc(black_box(&HEAP_ALLOCATOR)))
+        b.iter(|| small_alloc(std::hint::black_box(&HEAP_ALLOCATOR)))
     });
     c.bench_function("large alloc", |b| {
-        b.iter(|| large_alloc(black_box(&HEAP_ALLOCATOR)))
+        b.iter(|| large_alloc(std::hint::black_box(&HEAP_ALLOCATOR)))
     });
     c.bench_function("mutil thread random size", |b| {
-        b.iter(|| mutil_thread_random_size(black_box(&HEAP_ALLOCATOR)))
+        b.iter(|| mutil_thread_random_size(std::hint::black_box(&HEAP_ALLOCATOR)))
     });
     c.bench_function("threadtest", |b| b.iter(thread_test));
 }


### PR DESCRIPTION
## 概要

这个 PR 为 `Heap` 添加了一个 Criterion benchmark，用来构造一种碎片化场景：在释放内存时，`dealloc` 需要在较长的 free list 中查找 buddy block。

这个 PR **只添加 benchmark**，不修改 allocator 的任何行为。

## 背景

我在把 `buddy_system_allocator::Heap` 用作内核堆分配器时，遇到过一种 workload：大量重复的分配和释放会让某些 size class 的 free list 变长。

当前 `Heap::dealloc` 的逻辑会先计算 buddy 地址，但随后仍然需要遍历 `free_list[current_class]`，确认对应的 buddy block 是否处于空闲状态。在碎片化比较明显的场景下，释放路径的开销会受到 free list 长度影响。

这个 benchmark 的目的，是在本仓库内提供一个尽量小的可复现场景，方便后续评估相关优化。

## 本地测试结果

我在本地运行：

```bash
cargo bench --bench heap_dealloc_scan
```
</code></pre><p>得到结果如下：</p>
Case | Time
-- | --
100_pairs | 24.4 µs
500_pairs | 1.43 ms
1000_pairs | 5.93 ms
2000_pairs | 25.1 ms
5000_pairs | 217 ms


<p>较大的 case 是有意保留的压力场景，主要用于观察当 benchmark 构造出较长 free list 后，释放路径成本随之增长的趋势。可以看到性能的退化还是较为明显的，并且在我们内核的实践上，发现这样程度的退化对性能的影响较为显著</p><h2>benchmark 做了什么</h2><p>这个 benchmark 大致会：</p><ol><li><p>初始化一个独立的 <code>Heap</code>；</p></li><li><p>分配大量相同大小的块；</p></li><li><p>按特定模式释放其中一部分块，让某个 size class 的 free list 变长；</p></li><li><p>再释放另一部分块，触发 <code>dealloc</code> 中的 buddy lookup 路径。</p></li></ol><p>benchmark 直接使用 <code>Heap</code>，没有使用 <code>LockedHeap</code>，这样可以尽量排除锁开销，更专注于 allocator 本身的行为。</p><h2>后续想法</h2><p>如果这个 benchmark 被认为有价值，我后续想继续探索一个可选的 metadata-backed heap 实现。</p><p>大致思路是参考页分配器中常见的做法：不要只把 free list 当作唯一的状态来源，而是为被管理的 block 维护显式 metadata，记录 block 的状态和 order。这样在 <code>dealloc</code> 时，可以通过 buddy 地址直接判断 buddy block 是否空闲，而不必线性扫描当前 order 的 free list。</p><p>后续可能的实现方向：</p><ul><li><p>默认保持现有 <code>Heap</code> / <code>LockedHeap</code> 行为不变；</p></li><li><p>新增一个可选 feature，或者新增一个 metadata-backed heap 类型；</p></li><li><p>显式记录 block 的状态和 order；</p></li><li><p>使用 per-order free area，并支持 O(1) unlink；</p></li><li><p>尽量复用现有 heap 测试，验证新实现和现有行为的一致性；</p></li><li><p>用这个 benchmark 对比优化前后的表现。</p></li></ul><p>我还不确定这个方向是否适合本项目，所以希望先通过这个 benchmark PR 收集一下维护者的意见，再决定是否继续实现。